### PR TITLE
Fetch wasmparser and wast from https://github.com/effect-handlers/was…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "toml",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wat",
 ]
 
@@ -840,7 +840,7 @@ dependencies = [
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wasmtime-types",
  "wat",
 ]
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.25.0"
-source = "git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge#c2d30c97303fa031dfdf1b3a919879cfc089e0ec"
+source = "git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations#0d8f76c30c0ed35e2246afa7270e7487846f17f0"
 dependencies = [
  "leb128",
 ]
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.102.0"
-source = "git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge#c2d30c97303fa031dfdf1b3a919879cfc089e0ec"
+source = "git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations#0d8f76c30c0ed35e2246afa7270e7487846f17f0"
 dependencies = [
  "indexmap",
  "url",
@@ -3733,7 +3733,7 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-cap-std-sync",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -3848,7 +3848,7 @@ dependencies = [
  "test-programs",
  "tokio",
  "wasm-coredump-builder",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3863,7 +3863,7 @@ dependencies = [
  "wasmtime-wasi-nn",
  "wasmtime-wasi-threads",
  "wasmtime-wast",
- "wast 55.0.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wast 55.0.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wat",
  "windows-sys 0.45.0",
 ]
@@ -3916,7 +3916,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
 ]
@@ -3952,7 +3952,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-encoder 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3967,7 +3967,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger 0.9.3",
  "libfuzzer-sys",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -4045,7 +4045,7 @@ dependencies = [
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -4125,7 +4125,7 @@ dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
 ]
 
 [[package]]
@@ -4199,7 +4199,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 55.0.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wast 55.0.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
 ]
 
 [[package]]
@@ -4211,7 +4211,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "winch-codegen",
@@ -4251,12 +4251,12 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "55.0.0"
-source = "git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge#c2d30c97303fa031dfdf1b3a919879cfc089e0ec"
+source = "git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations#0d8f76c30c0ed35e2246afa7270e7487846f17f0"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.25.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasm-encoder 0.25.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
 ]
 
 [[package]]
@@ -4393,14 +4393,14 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
 ]
 
 [[package]]
 name = "winch-environ"
 version = "0.7.0"
 dependencies = [
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wasmtime-environ",
  "winch-codegen",
 ]
@@ -4446,7 +4446,7 @@ dependencies = [
  "similar",
  "target-lexicon",
  "toml",
- "wasmparser 0.102.0 (git+https://github.com/dhil/wasm-tools?branch=typed-continuations-function-references-merge)",
+ "wasmparser 0.102.0 (git+https://github.com/effect-handlers/wasm-tools?branch=typed-continuations)",
  "wasmtime-environ",
  "wat",
  "winch-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,9 +175,9 @@ winch-test-macros = { path = "winch/test-macros" }
 
 target-lexicon = { version = "0.12.3", default-features = false, features = ["std"] }
 anyhow = "1.0.22"
-wasmparser = { git = "https://github.com/dhil/wasm-tools", branch = "typed-continuations-function-references-merge" }
+wasmparser = { git = "https://github.com/effect-handlers/wasm-tools", branch = "typed-continuations" }
 wat = "1.0.61"
-wast = { git = "https://github.com/dhil/wasm-tools", branch = "typed-continuations-function-references-merge" }
+wast = { git = "https://github.com/effect-handlers/wasm-tools", branch = "typed-continuations" }
 wasmprinter = "0.2.54"
 wasm-encoder = "0.25.0"
 wasm-smith = "0.12.5"


### PR DESCRIPTION
This commit fetches wasmparser and wast from our main development repository rather than my private fork.
