### PR TITLE
Bring typed continuations up to date

### DIFF
--- a/crates/wasmtime/src/compiler.rs
+++ b/crates/wasmtime/src/compiler.rs
@@ -348,7 +348,7 @@ impl<'a> CompileInputs<'a> {
             }
 
             sigs.extend(translation.module.types.iter().map(|(_, ty)| match ty {
-                ModuleType::Function(ty) => (*ty, translation),
+                ModuleType::Function(ty) | ModuleType::Continuation(ty) => (*ty, translation),
             }));
         }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -844,7 +844,6 @@ fn generate_coredump(err: &anyhow::Error, source_name: &str, coredump_path: &str
             instanceidx,
             f.func_index(),
             u32::try_from(f.func_offset().unwrap_or(0)).unwrap(),
-            0, // TODO(dhil): I've pulled this offset out of thin air. It would get fixed by upstream eventually.
             // We don't currently have access to locals/stack values
             [],
             [],


### PR DESCRIPTION
This patch brings the typed continuations branch up to date with the recent changes to upstream/main, effect-handlers/function-references, and patch effect-handlers/wasm-tools/pull/42.