### PR TITLE
Translation state & VMContext field

### DIFF
--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -77,7 +77,7 @@ use super::{hash_map, HashMap};
 use crate::environ::{FuncEnvironment, GlobalVariable};
 use crate::state::{ControlStackFrame, ElseData, FuncTranslationState};
 use crate::translation_utils::{
-    block_with_params, blocktype_params_results, f32_translation, f64_translation,
+    block_with_params, block_with_params_wasmtype, blocktype_params_results, f32_translation, f64_translation,
 };
 use crate::wasm_unsupported;
 use crate::{FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TypeIndex, WasmResult};
@@ -2415,50 +2415,141 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             type_index,
             resumetable,
         } => {
-            let _arity = environ.continuation_arity(*type_index);
-            //println!("arity: {}", _arity);
-            let call_args = vec![];
-            let cont = state.pop1();
-            let jmpn = environ.translate_resume(builder.cursor(), state, cont, &call_args)?;
-            // This assumes cont will be modified in-place
-            state.push1(cont);
-            state.push1(jmpn);
+            // Idea create wrapper block for handling suspends:
+            // (resume ...)
+            // (if returned_normally then return code else resumetable code)
 
-            let mut targets = vec![];
-            for (tag, label) in resumetable.targets().map(|x| x.unwrap()) {
-                let tag = tag as usize;
-                if targets.len() <= tag {
-                    targets.resize(tag + 1, 0) // it's okay to put zeroes because typechecker ensured this makes sense
-                }
-                targets[tag] = label + 1; // We add 1 because of our silly extra block desugar below
+            // First we pop the arguments off the stack and bundle
+            // them up. The arguments are laid out on the stack as
+            // follows.
+            //
+            //  [ arg1 ... argN cont ]
+            let arity = environ.continuation_arity(*type_index);
+            let resume_args = state.peekn(arity + 1);
+
+            // Now, we generate the call instruction.
+            let (payload_addr, results_addr, signal, tag) = environ.translate_resume(builder, state, &resume_args)?;
+            // The `payload_addr` is the address of payload object
+            // that will have been created by a return or suspend. The
+            // `result` is an integer indicating whether the `resume`
+            // returned through an ordinary return or a suspension.
+
+            // Pop the `resume_args` off the stack.
+            state.popn(arity+1);
+
+            // Now, construct blocks for the three continuations:
+            // 1) `resume` returned normally.
+            // 2) `resume` returned via a suspend.
+            // 3) `resume` is forwarding (TODO)
+
+            let is_zero = builder.ins().icmp_imm(IntCC::Equal, signal, 0);
+            let returns = environ.continuation_returns(*type_index);
+            let return_block = block_with_params_wasmtype(builder, returns, environ)?;
+            let suspend_block = builder.create_block();
+            let mut returns_vals = vec![];
+            if returns.len() == 0 {
+                // OK
+            } else if returns.len() == 1 {
+                returns_vals.push(results_addr);
+            } else {
+                panic!("Unsupported continuation arity!");
             }
+            canonicalise_brif(builder, is_zero, return_block, &returns_vals, suspend_block, &[]);
 
-            // We wrap a br_table in a block so we can assign "just keep going"
-            // to the default value (9999 from libcall = br 0)
-            translate_operator(
-                validator,
-                &Operator::Block {
-                    // We want to keep a continuation on the stack for the
-                    // suspend cases. Even though in this case (return) we
-                    // simply drop / deallocate the continuation, we still need to
-                    // keep it around for the clif typechecking
-                    // TODO: i'm choosing some arbitrary type index here to
-                    // represent "a type index" because i believe clif doesn't
-                    // have any coarser type-checking and we simply drop the value
-                    blockty: wasmparser::BlockType::Type(wasmparser::ValType::Ref(
-                        wasmparser::RefType::indexed_func(false, *type_index).unwrap(),
-                    )),
-                },
-                builder,
-                state,
-                environ,
-            )?;
-            translate_resume_table(builder, state, targets)?;
-            translate_operator(validator, &Operator::End, builder, state, environ)?;
+            // Next, build the resume table.
+            builder.switch_to_block(suspend_block);
+            builder.seal_block(suspend_block);
+            // Push the payloads
+            //state.push1(todo!());
+            // Push the continuation object
+            let cont = payload_addr;
+            state.push1(cont);
+            // Push the suspend tag.
+            state.push1(tag);
+
+            //translate_resume_table(builder, state, resumetable)?;
+            builder.ins().trap(ir::TrapCode::UnreachableCodeReached);
+
+            // Now, finish the return block
+            builder.switch_to_block(return_block);
+            builder.seal_block(return_block);
+
+            // Push the results
+            state.push1(results_addr);
+
+            // let next_block = builder.create_block();
+            // let (params, results) = blocktype_params_results(validator, *blockty)?;
+            // let (destination, else_data) = if params.clone().eq(results.clone()) {
+            //     // It is possible there is no `else` block, so we will only
+            //     // allocate a block for it if/when we find the `else`. For now,
+            //     // we if the condition isn't true, then we jump directly to the
+            //     // destination block following the whole `if...end`. If we do end
+            //     // up discovering an `else`, then we will allocate a block for it
+            //     // and go back and patch the jump.
+            //     let destination = block_with_params(builder, results.clone(), environ)?;
+            //     let branch_inst = canonicalise_brif(
+            //         builder,
+            //         val,
+            //         next_block,
+            //         &[],
+            //         destination,
+            //         state.peekn(params.len()),
+            //     );
+            //     (
+            //         destination,
+            //         ElseData::NoElse {
+            //             branch_inst,
+            //             placeholder: destination,
+            //         },
+            //     )
+
+            // state.push1(payload_addr);
+            // state.push1(result);
+
+
+            // // TODO(dhil): The following is Luna's desugaring of
+            // // resume table into a BrTable. It introduces a new
+            // // synthetic block, which has the effect of "shifting" the
+            // // label indices ("shifting" in the sense of de
+            // // Bruijn). We ought to scrutinise the return of
+            // // `translate_resume` to decide whether to jump to one of
+            // // the resume table labels.
+            // let mut targets = vec![];
+            // for (tag, label) in resumetable.targets().map(|x| x.unwrap()) {
+            //     let tag = tag as usize;
+            //     if targets.len() <= tag {
+            //         targets.resize(tag + 1, 0) // it's okay to put zeroes because typechecker ensured this makes sense
+            //     }
+            //     targets[tag] = label + 1; // We add 1 because of our silly extra block desugar below
+            // }
+
+            // // We wrap a br_table in a block so we can assign "just keep going"
+            // // to the default value (9999 from libcall = br 0)
+            // translate_operator(
+            //     validator,
+            //     &Operator::Block {
+            //         // We want to keep a continuation on the stack for the
+            //         // suspend cases. Even though in this case (return) we
+            //         // simply drop / deallocate the continuation, we still need to
+            //         // keep it around for the clif typechecking
+            //         // TODO: i'm choosing some arbitrary type index here to
+            //         // represent "a type index" because i believe clif doesn't
+            //         // have any coarser type-checking and we simply drop the value
+            //         blockty: wasmparser::BlockType::Type(wasmparser::ValType::Ref(
+            //             wasmparser::RefType::indexed_func(false, *type_index).unwrap(),
+            //         )),
+            //         //blockty: wasmparser::BlockType::Empty,
+            //     },
+            //     builder,
+            //     state,
+            //     environ,
+            // )?;
+            // translate_resume_table(builder, state, targets)?;
+            // translate_operator(validator, &Operator::End, builder, state, environ)?;
             // We kept a continuation on the stack for the suspend cases, but
             // on return we have no continuation. so drop that continuation that
             // is now completely invalidated (something about deallocate?)
-            translate_operator(validator, &Operator::Drop, builder, state, environ)?;
+            //translate_operator(validator, &Operator::Drop, builder, state, environ)?;
         }
         Operator::Suspend { tag_index } => {
             environ.translate_suspend(builder.cursor(), state, *tag_index);
@@ -2481,9 +2572,18 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
 fn translate_resume_table(
     builder: &mut FunctionBuilder,
     state: &mut FuncTranslationState,
-    targets: Vec<u32>,
+    resumetable: &wasmparser::ResumeTable<'_>,
 ) -> WasmResult<()> {
-    let default = 0;
+    let mut targets = vec![];
+    for (tag, label) in resumetable.targets().map(|x| x.unwrap()) {
+        let tag = tag as usize;
+        if targets.len() <= tag {
+            targets.resize(tag + 1, 0) // it's okay to put zeroes because typechecker ensured this makes sense
+        }
+        targets[tag] = label; // We add 1 because of our silly extra block desugar below
+    }
+
+    let default = 0; // HACK
     let mut min_depth = default;
     for depth in targets.clone() {
         if depth < min_depth {

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2445,7 +2445,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let is_zero = builder.ins().icmp_imm(IntCC::Equal, signal, 0);
             let returns = environ.continuation_returns(*type_index);
             let return_block = block_with_params_wasmtype(builder, returns, environ)?;
-            let suspend_block = builder.create_block();
+            let suspend_block = crate::translation_utils::suspend_block(builder, environ)?;
             let mut returns_vals = vec![];
             if returns.len() == 0 {
                 // OK
@@ -2454,7 +2454,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             } else {
                 panic!("Unsupported continuation arity!");
             }
-            canonicalise_brif(builder, is_zero, return_block, &returns_vals, suspend_block, &[]);
+            canonicalise_brif(builder, is_zero, return_block, &returns_vals, suspend_block, &[tag, payload_addr]);
 
             // Next, build the resume table.
             builder.switch_to_block(suspend_block);

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2409,7 +2409,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
 
         Operator::ContNew { type_index: _ } => {
             let r = state.pop1();
-            state.push1(environ.translate_cont_new(builder.cursor(), r)?);
+            state.push1(environ.translate_cont_new(builder.cursor(), state, r)?);
         }
         Operator::Resume {
             type_index,
@@ -2419,7 +2419,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             //println!("arity: {}", _arity);
             let call_args = vec![];
             let cont = state.pop1();
-            let jmpn = environ.translate_resume(builder.cursor(), cont, &call_args)?;
+            let jmpn = environ.translate_resume(builder.cursor(), state, cont, &call_args)?;
             // This assumes cont will be modified in-place
             state.push1(cont);
             state.push1(jmpn);
@@ -2461,7 +2461,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             translate_operator(validator, &Operator::Drop, builder, state, environ)?;
         }
         Operator::Suspend { tag_index } => {
-            environ.translate_suspend(builder.cursor(), *tag_index);
+            environ.translate_suspend(builder.cursor(), state, *tag_index);
         }
         Operator::ContBind {
             src_index: _,

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -679,11 +679,10 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
 
     fn translate_resume(
         &mut self,
-        _pos: FuncCursor,
+        _builder: &mut FunctionBuilder,
         _state: &FuncTranslationState,
-        _cont: ir::Value,
-        _call_args: &[ir::Value],
-    ) -> WasmResult<ir::Value> {
+        _resume_args: &[ir::Value],
+    ) -> WasmResult<(ir::Value, ir::Value, ir::Value, ir::Value)> {
         todo!()
     }
 
@@ -702,6 +701,10 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
     }
 
     fn continuation_arity(&self, _type_index: u32) -> usize {
+        todo!()
+    }
+
+    fn continuation_returns(&self, _type_index: u32) -> &[WasmType] {
         todo!()
     }
 }

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -673,13 +673,14 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         Ok(pos.ins().iconst(I32, 0))
     }
 
-    fn translate_cont_new(&mut self, _pos: FuncCursor, _func: ir::Value) -> WasmResult<ir::Value> {
+    fn translate_cont_new(&mut self, _pos: FuncCursor, _state: &FuncTranslationState, _func: ir::Value) -> WasmResult<ir::Value> {
         todo!()
     }
 
     fn translate_resume(
         &mut self,
         _pos: FuncCursor,
+        _state: &FuncTranslationState,
         _cont: ir::Value,
         _call_args: &[ir::Value],
     ) -> WasmResult<ir::Value> {
@@ -689,13 +690,14 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
     fn translate_resume_throw(
         &mut self,
         _pos: FuncCursor,
+        _state: &FuncTranslationState,
         _tag_index: u32,
         _cont: ir::Value,
     ) -> WasmResult<ir::Value> {
         todo!()
     }
 
-    fn translate_suspend(&mut self, _pos: FuncCursor, _tag_index: u32) {
+    fn translate_suspend(&mut self, _pos: FuncCursor, _state: &FuncTranslationState, _tag_index: u32) {
         todo!()
     }
 

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -682,7 +682,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         _builder: &mut FunctionBuilder,
         _state: &FuncTranslationState,
         _resume_args: &[ir::Value],
-    ) -> WasmResult<(ir::Value, ir::Value, ir::Value, ir::Value)> {
+    ) -> WasmResult<(ir::Value, ir::Value, ir::Value)> {
         todo!()
     }
 
@@ -708,7 +708,11 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         todo!()
     }
 
-    fn unbox_values(&self, _builder: &mut FunctionBuilder, _valtypes: &[WasmType], _base_addr: ir::Value) -> Vec<ir::Value> {
+    fn typed_continuations_load_payloads(&self, _builder: &mut FunctionBuilder, _valtypes: &[WasmType], _base_addr: ir::Value) -> Vec<ir::Value> {
+        todo!()
+    }
+
+    fn typed_continuations_load_continuation_object(&self, _builder: &mut FunctionBuilder, _base_addr: ir::Value) -> ir::Value {
         todo!()
     }
 }

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -707,6 +707,10 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
     fn continuation_returns(&self, _type_index: u32) -> &[WasmType] {
         todo!()
     }
+
+    fn unbox_values(&self, _builder: &mut FunctionBuilder, _valtypes: &[WasmType], _base_addr: ir::Value) -> Vec<ir::Value> {
+        todo!()
+    }
 }
 
 impl TypeConvert for DummyEnvironment {

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -569,11 +569,10 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// TODO(dhil): write documentation.
     fn translate_resume(
         &mut self,
-        pos: FuncCursor,
+        builder: &mut FunctionBuilder,
         state: &FuncTranslationState,
-        cont: ir::Value,
-        call_args: &[ir::Value],
-    ) -> WasmResult<ir::Value>;
+        resume_args: &[ir::Value],
+    ) -> WasmResult<(ir::Value, ir::Value, ir::Value, ir::Value)>;
 
     /// TODO(dhil): write documentation.
     fn translate_resume_throw(
@@ -589,6 +588,9 @@ pub trait FuncEnvironment: TargetEnvironment {
 
     /// TODO
     fn continuation_arity(&self, type_index: u32) -> usize;
+
+    /// TODO
+    fn continuation_returns(&self, type_index: u32) -> &[wasmtime_types::WasmType];
 
     /// Returns whether the CLIF `x86_blendv` instruction should be used for the
     /// relaxed simd `*.relaxed_laneselect` instruction for the specified type.

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -572,7 +572,7 @@ pub trait FuncEnvironment: TargetEnvironment {
         builder: &mut FunctionBuilder,
         state: &FuncTranslationState,
         resume_args: &[ir::Value],
-    ) -> WasmResult<(ir::Value, ir::Value, ir::Value, ir::Value)>;
+    ) -> WasmResult<(ir::Value, ir::Value, ir::Value)>;
 
     /// TODO(dhil): write documentation.
     fn translate_resume_throw(
@@ -593,7 +593,10 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn continuation_returns(&self, type_index: u32) -> &[wasmtime_types::WasmType];
 
     /// TODO
-    fn unbox_values(&self, builder: &mut FunctionBuilder, valtypes: &[wasmtime_types::WasmType], base_addr: ir::Value) -> std::vec::Vec<ir::Value>;
+    fn typed_continuations_load_payloads(&self, builder: &mut FunctionBuilder, valtypes: &[wasmtime_types::WasmType], base_addr: ir::Value) -> std::vec::Vec<ir::Value>;
+
+    /// TODO
+    fn typed_continuations_load_continuation_object(&self, builder: &mut FunctionBuilder, base_addr: ir::Value) -> ir::Value;
 
     /// Returns whether the CLIF `x86_blendv` instruction should be used for the
     /// relaxed simd `*.relaxed_laneselect` instruction for the specified type.

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -564,12 +564,13 @@ pub trait FuncEnvironment: TargetEnvironment {
     }
 
     /// TODO(dhil): write documentation.
-    fn translate_cont_new(&mut self, pos: FuncCursor, func: ir::Value) -> WasmResult<ir::Value>;
+    fn translate_cont_new(&mut self, pos: FuncCursor, state: &FuncTranslationState, func: ir::Value) -> WasmResult<ir::Value>;
 
     /// TODO(dhil): write documentation.
     fn translate_resume(
         &mut self,
         pos: FuncCursor,
+        state: &FuncTranslationState,
         cont: ir::Value,
         call_args: &[ir::Value],
     ) -> WasmResult<ir::Value>;
@@ -578,12 +579,13 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn translate_resume_throw(
         &mut self,
         pos: FuncCursor,
+        state: &FuncTranslationState,
         tag_index: u32,
         cont: ir::Value,
     ) -> WasmResult<ir::Value>;
 
     /// TODO(dhil): write documentation.
-    fn translate_suspend(&mut self, pos: FuncCursor, tag_index: u32);
+    fn translate_suspend(&mut self, pos: FuncCursor, state: &FuncTranslationState, tag_index: u32);
 
     /// TODO
     fn continuation_arity(&self, type_index: u32) -> usize;

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -566,7 +566,11 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// TODO(dhil): write documentation.
     fn translate_cont_new(&mut self, pos: FuncCursor, state: &FuncTranslationState, func: ir::Value) -> WasmResult<ir::Value>;
 
-    /// TODO(dhil): write documentation.
+    /// Translates a resume instruction and returns a triple (vmctx,
+    /// signal, tag), where vmctx is the base address of the VM
+    /// context, signal is high bit of the resume result, and tag is
+    /// the index of the control tag supplied to suspend (if the
+    /// signal is 1).
     fn translate_resume(
         &mut self,
         builder: &mut FunctionBuilder,

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -592,6 +592,9 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// TODO
     fn continuation_returns(&self, type_index: u32) -> &[wasmtime_types::WasmType];
 
+    /// TODO
+    fn unbox_values(&self, builder: &mut FunctionBuilder, valtypes: &[wasmtime_types::WasmType], base_addr: ir::Value) -> std::vec::Vec<ir::Value>;
+
     /// Returns whether the CLIF `x86_blendv` instruction should be used for the
     /// relaxed simd `*.relaxed_laneselect` instruction for the specified type.
     fn use_x86_blendv_for_relaxed_laneselect(&self, ty: Type) -> bool {

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -264,6 +264,7 @@ fn parse_function_body<FE: FuncEnvironment + ?Sized>(
         translate_operator(validator, &op, builder, state, environ)?;
         environ.after_translate_operator(&op, builder, state)?;
     }
+    println!("func: {:?}", builder.func);
     environ.after_translate_function(builder, state)?;
     let pos = reader.original_position();
     validator.finish(pos)?;

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -6,8 +6,8 @@ use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
-use wasmparser::{FuncValidator, WasmFuncType, WasmModuleResources};
-use wasmtime_types::WasmType;
+use wasmparser::{FuncValidator, WasmFuncType,  WasmModuleResources};
+use wasmtime_types::{WasmType, WasmHeapType};
 
 /// Get the parameter and result types for the given Wasm blocktype.
 pub fn blocktype_params_results<'a, T>(
@@ -128,5 +128,21 @@ pub fn block_with_params_wasmtype<PE: TargetEnvironment + ?Sized>(
             }
         }
     }
+    Ok(block)
+}
+
+/// Create a synthetic suspend block (used to wrap a resume table).
+pub fn suspend_block<PE: TargetEnvironment + ?Sized>(
+    builder: &mut FunctionBuilder,
+    environ: &PE,
+) -> WasmResult<ir::Block> {
+    let block = builder.create_block();
+    // Tag type
+    builder.append_block_param(block, ir::types::I32);
+    // Cont type
+    builder.append_block_param(block, environ.reference_type(WasmHeapType::Func));
+    // Payload pointer
+    // builder.append_block_param(block, environ.pointer_type());
+
     Ok(block)
 }

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -139,10 +139,36 @@ pub fn suspend_block<PE: TargetEnvironment + ?Sized>(
     let block = builder.create_block();
     // Tag type
     builder.append_block_param(block, ir::types::I32);
-    // Cont type
+    // VM context pointer
+    builder.append_block_param(block, environ.pointer_type());
+
+    Ok(block)
+}
+
+/// Create a synthetic resume table entry block.
+pub fn resumetable_entry_block<PE: TargetEnvironment + ?Sized>(
+    builder: &mut FunctionBuilder,
+    environ: &PE,
+) -> WasmResult<ir::Block> {
+    let block = builder.create_block();
+    // VM context pointer
+    builder.append_block_param(block, environ.pointer_type());
+    // Continuation object pointer
     builder.append_block_param(block, environ.reference_type(WasmHeapType::Func));
-    // Payload pointer
-    // builder.append_block_param(block, environ.pointer_type());
+
+    Ok(block)
+}
+
+/// Create a synthetic resume table forwarding block.
+pub fn resumetable_forwarding_block<PE: TargetEnvironment + ?Sized>(
+    builder: &mut FunctionBuilder,
+    environ: &PE,
+) -> WasmResult<ir::Block> {
+    let block = builder.create_block();
+    // VM context pointer
+    builder.append_block_param(block, environ.pointer_type());
+    // Continuation object pointer
+    builder.append_block_param(block, environ.reference_type(WasmHeapType::Func));
 
     Ok(block)
 }
@@ -154,7 +180,7 @@ pub fn return_block<PE: TargetEnvironment + ?Sized>(
     environ: &PE,
 ) -> WasmResult<ir::Block> {
     let block = builder.create_block();
-    // Pointer to return payload.
+    // VM context pointer
     builder.append_block_param(block, environ.pointer_type());
 
     Ok(block)

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -7,6 +7,7 @@ use cranelift_frontend::FunctionBuilder;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmparser::{FuncValidator, WasmFuncType, WasmModuleResources};
+use wasmtime_types::WasmType;
 
 /// Get the parameter and result types for the given Wasm blocktype.
 pub fn blocktype_params_results<'a, T>(
@@ -96,4 +97,36 @@ pub fn f64_translation(x: wasmparser::Ieee64) -> ir::immediates::Ieee64 {
 pub fn get_vmctx_value_label() -> ir::ValueLabel {
     const VMCTX_LABEL: u32 = 0xffff_fffe;
     ir::ValueLabel::from_u32(VMCTX_LABEL)
+}
+
+/// Create a `Block` with the given Wasm parameters.
+pub fn block_with_params_wasmtype<PE: TargetEnvironment + ?Sized>(
+    builder: &mut FunctionBuilder,
+    params: &[WasmType],
+    environ: &PE,
+) -> WasmResult<ir::Block> {
+    let block = builder.create_block();
+    for ty in params {
+        match ty {
+            WasmType::I32 => {
+                builder.append_block_param(block, ir::types::I32);
+            }
+            WasmType::I64 => {
+                builder.append_block_param(block, ir::types::I64);
+            }
+            WasmType::F32 => {
+                builder.append_block_param(block, ir::types::F32);
+            }
+            WasmType::F64 => {
+                builder.append_block_param(block, ir::types::F64);
+            }
+            WasmType::Ref(rt) => {
+                builder.append_block_param(block, environ.reference_type(rt.heap_type));
+            }
+            WasmType::V128 => {
+                builder.append_block_param(block, ir::types::I8X16);
+            }
+        }
+    }
+    Ok(block)
 }

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -146,3 +146,16 @@ pub fn suspend_block<PE: TargetEnvironment + ?Sized>(
 
     Ok(block)
 }
+
+/// Create a synthetic return block (used to wrap the return
+/// continuation of resume).
+pub fn return_block<PE: TargetEnvironment + ?Sized>(
+    builder: &mut FunctionBuilder,
+    environ: &PE,
+) -> WasmResult<ir::Block> {
+    let block = builder.create_block();
+    // Pointer to return payload.
+    builder.append_block_param(block, environ.pointer_type());
+
+    Ok(block)
+}

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2203,6 +2203,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     fn translate_cont_new(
         &mut self,
         mut pos: cranelift_codegen::cursor::FuncCursor<'_>,
+        _state: &FuncTranslationState,
         func: ir::Value,
     ) -> WasmResult<ir::Value> {
         let builtin_index = BuiltinFunctionIndex::cont_new();
@@ -2219,6 +2220,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     fn translate_resume(
         &mut self,
         mut pos: cranelift_codegen::cursor::FuncCursor<'_>,
+        _state: &FuncTranslationState,
         cont: ir::Value,
         _call_args: &[ir::Value],
     ) -> WasmResult<ir::Value> {
@@ -2238,6 +2240,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     fn translate_resume_throw(
         &mut self,
         _pos: FuncCursor,
+        _state: &FuncTranslationState,
         _tag_index: u32,
         _cont: ir::Value,
     ) -> WasmResult<ir::Value> {
@@ -2247,6 +2250,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     fn translate_suspend(
         &mut self,
         mut pos: cranelift_codegen::cursor::FuncCursor<'_>,
+        _state: &FuncTranslationState,
         tag_index: u32,
     ) {
         let builtin_index = BuiltinFunctionIndex::suspend();

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -95,6 +95,7 @@ pub struct VMOffsets<P> {
     // NOTE(dhil): The following field is used as "global" to store
     // the arguments of continuations and payloads of suspensions.
     typed_continuations_store: u32,
+    typed_continuations_payloads: u32,
 }
 
 /// Trait used for the `ptr` representation of the field of `VMOffsets`
@@ -356,6 +357,7 @@ impl<P: PtrSize> VMOffsets<P> {
         }
 
         calculate_sizes! {
+            typed_continuations_payloads: "typed continuations payloads",
             typed_continuations_store: "typed continuations store",
             defined_func_refs: "module functions",
             defined_globals: "defined globals",
@@ -371,7 +373,7 @@ impl<P: PtrSize> VMOffsets<P> {
             store: "jit store state",
             externref_activations_table: "jit host externref state",
             epoch_ptr: "jit current epoch state",
-            callee:  "callee function pointer",
+            callee: "callee function pointer",
             runtime_limits: "jit runtime limits state",
             magic: "magic value",
         }
@@ -410,6 +412,7 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             defined_func_refs: 0,
             size: 0,
             typed_continuations_store: 0,
+            typed_continuations_payloads: 0,
         };
 
         // Convenience functions for checked addition and multiplication.
@@ -474,6 +477,9 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             ),
             size(typed_continuations_store)
                 = ret.ptr.size(),
+            align(16),
+            size(typed_continuations_payloads)
+                = cmul(6, ret.ptr.size()),
             align(16), // TODO(dhil): This could probably be done more
                        // efficiently by packing the pointer into the above 16 byte
                        // alignment
@@ -745,6 +751,12 @@ impl<P: PtrSize> VMOffsets<P> {
     #[inline]
     pub fn vmctx_typed_continuations_store(&self) -> u32 {
         self.typed_continuations_store
+    }
+
+    /// The offset of the typed continuations payloads store.
+    #[inline]
+    pub fn vmctx_typed_continuations_payloads(&self) -> u32 {
+        self.typed_continuations_payloads
     }
 
     /// Return the size of the `VMContext` allocation.

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -91,6 +91,10 @@ pub struct VMOffsets<P> {
     defined_globals: u32,
     defined_func_refs: u32,
     size: u32,
+
+    // NOTE(dhil): The following field is used as "global" to store
+    // the arguments of continuations and payloads of suspensions.
+    typed_continuations_store: u32,
 }
 
 /// Trait used for the `ptr` representation of the field of `VMOffsets`
@@ -352,6 +356,7 @@ impl<P: PtrSize> VMOffsets<P> {
         }
 
         calculate_sizes! {
+            typed_continuations_store: "typed continuations store",
             defined_func_refs: "module functions",
             defined_globals: "defined globals",
             owned_memories: "owned memories",
@@ -366,7 +371,7 @@ impl<P: PtrSize> VMOffsets<P> {
             store: "jit store state",
             externref_activations_table: "jit host externref state",
             epoch_ptr: "jit current epoch state",
-            callee: "callee function pointer",
+            callee:  "callee function pointer",
             runtime_limits: "jit runtime limits state",
             magic: "magic value",
         }
@@ -404,6 +409,7 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             defined_globals: 0,
             defined_func_refs: 0,
             size: 0,
+            typed_continuations_store: 0,
         };
 
         // Convenience functions for checked addition and multiplication.
@@ -466,6 +472,11 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
                 ret.num_escaped_funcs,
                 ret.ptr.size_of_vm_func_ref(),
             ),
+            size(typed_continuations_store)
+                = ret.ptr.size(),
+            align(16), // TODO(dhil): This could probably be done more
+                       // efficiently by packing the pointer into the above 16 byte
+                       // alignment
         }
 
         ret.size = next_field_offset;
@@ -728,6 +739,12 @@ impl<P: PtrSize> VMOffsets<P> {
     #[inline]
     pub fn vmctx_builtin_functions(&self) -> u32 {
         self.builtin_functions
+    }
+
+    /// The offset of the typed continuations store.
+    #[inline]
+    pub fn vmctx_typed_continuations_store(&self) -> u32 {
+        self.typed_continuations_store
     }
 
     /// Return the size of the `VMContext` allocation.

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -164,7 +164,6 @@ pub fn resume(instance: &mut Instance, cont: *mut u8) -> Result<u32, TrapReason>
             // Store the result.
             let payloads_addr = unsafe { instance.get_typed_continuations_payloads_mut() };
             unsafe {
-                println!("result: {:?}", result);
                 std::ptr::write(payloads_addr, result);
             }
 

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -161,9 +161,16 @@ pub fn resume(instance: &mut Instance, cont: *mut u8) -> Result<u32, TrapReason>
         Ok(_) => {
             let drop_box: Box<Fiber<_, _, _>> = unsafe { Box::from_raw(cont) };
             drop(drop_box); // I think this would be covered by the close brace below anyway
-            Ok(9999)
+            Ok(0) // zero value = return normally.
+            //Ok(9999)
         }
-        Err(y) => Ok(y),
+        Err(tag) => {
+            // We set the high bit to signal a return via suspend. We
+            // encode the tag into the remainder of the integer.
+            let signal_mask = 0b1000_0000_0000_0000_0000_0000_0000_0000;
+            debug_assert_eq!(tag & signal_mask, 0);
+            Ok(tag | signal_mask)
+        }, // 0 = suspend //Ok(y),
     }
 }
 

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -1,9 +1,8 @@
 //! Continuations TODO
 
 use crate::instance::TopOfStackPointer;
-use crate::vmcontext::{VMContext, VMFuncRef, VMFunctionBody, VMOpaqueContext, VMWasmCallFunction};
+use crate::vmcontext::{VMContext, VMFuncRef, VMOpaqueContext, VMWasmCallFunction};
 use crate::{Instance, TrapReason};
-use std::mem;
 use std::ptr::NonNull;
 use wasmtime_fiber::{Fiber, FiberStack, Suspend};
 

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -1,147 +1,37 @@
 //! Continuations TODO
 
 use crate::instance::TopOfStackPointer;
-use crate::vmcontext::{VMContext, VMFuncRef, VMFunctionBody, VMOpaqueContext};
+use crate::vmcontext::{VMContext, VMFuncRef, VMFunctionBody, VMOpaqueContext, VMWasmCallFunction};
 use crate::{Instance, TrapReason};
 use std::mem;
+use std::ptr::NonNull;
 use wasmtime_fiber::{Fiber, FiberStack, Suspend};
-
-// NOTE(dhil): Trampolines have disappeared from the wasmtime codebase
-// in favour of another mechanism. Presently, our code depends on
-// trampolines, so I have copied the necessary trampoline code in
-// here. We should ultimately fix our code such that we can use the
-// new mechanism.
-
-// Trampolines for calling into Wasm from the host and calling the host from
-// Wasm.
-
-/// Given a Wasm function pointer and a `vmctx`, prepare the `vmctx` for calling
-/// into that Wasm function, and return the host-to-Wasm entry trampoline.
-///
-/// Callers must never call Wasm function pointers directly. Callers must
-/// instead call this function and then enter Wasm through the returned
-/// host-to-Wasm trampoline.
-///
-/// # Unsafety
-///
-/// The `vmctx` argument must be valid.
-///
-/// The generic type `T` must be a function pointer type and `func` must be a
-/// pointer to a Wasm function of that signature.
-///
-/// After calling this function, you may not mess with the vmctx or any other
-/// Wasm state until after you've called the trampoline returned by this
-/// function.
-#[inline]
-pub unsafe fn prepare_host_to_wasm_trampoline<T>(vmctx: *mut VMContext, func: T) -> T {
-    assert_eq!(mem::size_of::<T>(), mem::size_of::<usize>());
-
-    // Save the callee in the `vmctx`. The trampoline will read this function
-    // pointer and tail call to it.
-    Instance::from_vmctx(vmctx, |instance: &mut Instance| {
-        instance.set_callee(Some(mem::transmute_copy(&func)))
-    });
-
-    // Give callers the trampoline, transmuted into their desired function
-    // signature (the trampoline is variadic and works with all signatures).
-    mem::transmute_copy(&(host_to_wasm_trampoline as usize))
-}
-
-extern "C" {
-    fn host_to_wasm_trampoline();
-}
-
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "x86_64")] {
-        use wasmtime_asm_macros::asm_func;
-
-        // Helper macros for getting the first and second arguments according to the
-        // system calling convention, as well as some callee-saved scratch registers we
-        // can safely use in the trampolines.
-        cfg_if::cfg_if! {
-            if #[cfg(unix)] {
-                macro_rules! wasmfx_arg0 { () => ("rdi") }
-                macro_rules! wasmfx_arg1 { () => ("rsi") }
-                macro_rules! wasmfx_scratch0 { () => ("r10") }
-                macro_rules! wasmfx_scratch1 { () => ("r11") }
-            } else {
-                compile_error!("platform not supported");
-            }
-        }
-
-        #[rustfmt::skip]
-        asm_func!(
-            "host_to_wasm_trampoline",
-            concat!(
-                "
-            .cfi_startproc simple
-            .cfi_def_cfa_offset 0
-
-            // Load the pointer to `VMRuntimeLimits` in `scratch0`.
-            mov ", wasmfx_scratch0!(), ", 8[", wasmfx_arg1!(), "]
-
-            // Check to see if this is a core `VMContext` (MAGIC == 'core').
-            cmp DWORD PTR [", wasmfx_arg0!(), "], 0x65726f63
-
-            // Store the last Wasm SP into the `last_wasm_entry_sp` in the limits, if this
-            // was core Wasm, otherwise store an invalid sentinal value.
-            mov ", wasmfx_scratch1!(), ", -1
-            cmove ", wasmfx_scratch1!(), ", rsp
-            mov 40[", wasmfx_scratch0!(), "], ", wasmfx_scratch1!(), "
-
-            // Tail call to the callee function pointer in the vmctx.
-            jmp 16[", wasmfx_arg1!(), "]
-
-            .cfi_endproc
-        ",
-            ),
-        );
-
-        #[cfg(test)]
-        mod host_to_wasm_trampoline_offsets_tests {
-            use wasmtime_environ::{Module, PtrSize, VMOffsets};
-
-            #[test]
-            fn test() {
-                let module = Module::new();
-                let offsets = VMOffsets::new(std::mem::size_of::<*mut u8>() as u8, &module);
-
-                assert_eq!(8, offsets.vmctx_runtime_limits());
-                assert_eq!(40, offsets.ptr.vmruntime_limits_last_wasm_entry_sp());
-                assert_eq!(16, offsets.vmctx_callee());
-                assert_eq!(0x65726f63, u32::from_le_bytes(*b"core"));
-            }
-        }
-    } else {
-        compile_error!("unsupported architecture");
-    }
-}
 
 /// TODO
 #[inline(always)]
 pub fn cont_new(instance: &mut Instance, func: *mut u8) -> *mut u8 {
     let func = func as *mut VMFuncRef;
-    let fnptr = unsafe { (*func).native_call.as_ptr() as *const VMFunctionBody };
-    let vmctx1 = unsafe { (*func).vmctx };
-    let vmctx2 = instance.vmctx();
+    let callee_ctx = unsafe { (*func).vmctx };
+    let caller_ctx = instance.vmctx();
+    let f = unsafe {
+        // TODO(dhil): Not sure whether we should use
+        // VMWasmCallFunction or VMNativeCallFunction here.
+        std::mem::transmute::<NonNull<VMWasmCallFunction>,
+                              unsafe extern "C" fn(*mut VMOpaqueContext,
+                                                   *mut VMContext, ()) -> u32,>(
+            (*func).wasm_call.unwrap()
+        )
+    };
     let fiber = Box::new(
         Fiber::new(
             FiberStack::new(4096).unwrap(),
-            move |first_val: (), _suspend: &Suspend<_, u32, u32>| {
-                let trampoline = unsafe {
-                    std::mem::transmute::<
-                        *const VMFunctionBody,
-                        unsafe extern "C" fn(*mut VMOpaqueContext, *mut VMContext, ()) -> u32,
-                    >(fnptr)
-                };
-                let trampoline = unsafe { prepare_host_to_wasm_trampoline(vmctx2, trampoline) };
-                unsafe { trampoline(vmctx1, vmctx2, first_val) }
+            move |_first_val: (), _suspend: &Suspend<(), u32, u32>| {
+                unsafe { f(callee_ctx, caller_ctx, ()) }
             },
-        )
-        .unwrap(),
+        ).unwrap()
     );
     let ptr: *mut Fiber<'static, (), u32, u32> = Box::into_raw(fiber);
-    ptr as *mut _
+    ptr as *mut u8
 }
 
 /// TODO

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -1187,6 +1187,16 @@ impl Instance {
         }
         fault
     }
+
+    /// TODO
+    pub unsafe fn get_typed_continuations_store_mut(&mut self) -> *mut u32 {
+        self.vmctx_plus_offset_mut(self.offsets().vmctx_typed_continuations_store())
+    }
+
+    /// TODO
+    pub unsafe fn get_typed_continuations_payloads_mut(&mut self) -> *mut u32 {
+        self.vmctx_plus_offset_mut(self.offsets().vmctx_typed_continuations_payloads())
+    }
 }
 
 impl Drop for Instance {

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -665,6 +665,8 @@ fn switch_image_and_non_image() -> Result<()> {
     Ok(())
 }
 
+// NOTE(dhil): this test is sensitive to the layout and (potentially
+// naming of fields) in crates/environ/src/vmoffsets.rs
 #[test]
 #[cfg(target_pointer_width = "64")]
 #[cfg_attr(miri, ignore)]
@@ -676,11 +678,12 @@ fn instance_too_large() -> Result<()> {
 
     let engine = Engine::new(&config)?;
     let expected = "\
-instance allocation for this module requires 256 bytes which exceeds the \
+instance allocation for this module requires 272 bytes which exceeds the \
 configured maximum of 16 bytes; breakdown of allocation requirement:
 
- * 68.75% - 176 bytes - instance state management
- * 6.25% - 16 bytes - jit store state
+ * 64.71% - 176 bytes - instance state management
+ * 5.88% - 16 bytes - typed continuations store
+ * 5.88% - 16 bytes - jit store state
 ";
     match Module::new(&engine, "(module)") {
         Ok(_) => panic!("should have failed to compile"),
@@ -694,11 +697,11 @@ configured maximum of 16 bytes; breakdown of allocation requirement:
     lots_of_globals.push_str(")");
 
     let expected = "\
-instance allocation for this module requires 1856 bytes which exceeds the \
+instance allocation for this module requires 1872 bytes which exceeds the \
 configured maximum of 16 bytes; breakdown of allocation requirement:
 
- * 9.48% - 176 bytes - instance state management
- * 86.21% - 1600 bytes - defined globals
+ * 9.40% - 176 bytes - instance state management
+ * 85.47% - 1600 bytes - defined globals
 ";
     match Module::new(&engine, &lots_of_globals) {
         Ok(_) => panic!("should have failed to compile"),

--- a/tests/misc_testsuite/typed-continuations/cont_resume.wast
+++ b/tests/misc_testsuite/typed-continuations/cont_resume.wast
@@ -14,4 +14,4 @@
     (global.get $i))
 )
 
-;; (assert_return (invoke "f") (i32.const 42))
+(assert_return (invoke "f") (i32.const 42))

--- a/tests/misc_testsuite/typed-continuations/cont_resume1.wast
+++ b/tests/misc_testsuite/typed-continuations/cont_resume1.wast
@@ -1,0 +1,27 @@
+(module
+  (type $ft_init (func))
+  (type $ct_init (cont $ft_init))
+  (type $ft (func (param i32)))
+  (type $ct (cont $ft))
+  (tag $yield (result i32))
+
+  (global $i (mut i32) (i32.const 0))
+
+  (func $g
+    (suspend $yield)
+    (global.set $i))
+  (elem declare func $g)
+
+  (func $f (export "f") (result i32)
+    (local $k (ref null $ct))
+    (global.set $i (i32.const 99))
+    (block $on_yield (result (ref $ct))
+      (resume $ct_init (tag $yield $on_yield) (cont.new $ct_init (ref.func $g)))
+      (unreachable))
+    ;; on_yield
+    (local.set $k)
+    (resume $ct (i32.const 42) (local.get $k))
+    (global.get $i))
+)
+
+(assert_return (invoke "f") (i32.const 42))

--- a/tests/misc_testsuite/typed-continuations/cont_resume_return.wast
+++ b/tests/misc_testsuite/typed-continuations/cont_resume_return.wast
@@ -1,0 +1,13 @@
+(module
+  (type $ft (func (result i32)))
+  (type $ct (cont $ft))
+
+  (func $g (result i32)
+    (i32.const 42))
+  (elem declare func $g)
+
+  (func $f (export "f") (result i32)
+    (resume $ct (cont.new $ct (ref.func $g))))
+)
+
+(assert_return (invoke "f") (i32.const 42))


### PR DESCRIPTION
This patch passes the translation state to the continuation instruction translation functions. It also extends the `VMContext` with an additional field `typed_continuations_store` for storing continuation arguments and suspend payloads.