### PR TITLE
run cargo fmt

### DIFF
--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -673,7 +673,13 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         Ok(pos.ins().iconst(I32, 0))
     }
 
-    fn translate_cont_new(&mut self, _pos: FuncCursor, _state: &FuncTranslationState, _func: ir::Value, _arg_types : &[wasmtime_types::WasmType]) -> WasmResult<ir::Value> {
+    fn translate_cont_new(
+        &mut self,
+        _pos: FuncCursor,
+        _state: &FuncTranslationState,
+        _func: ir::Value,
+        _arg_types: &[wasmtime_types::WasmType],
+    ) -> WasmResult<ir::Value> {
         todo!()
     }
 
@@ -681,9 +687,9 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         &mut self,
         _builder: &mut FunctionBuilder,
         _state: &FuncTranslationState,
-        _cont : ir::Value,
+        _cont: ir::Value,
         _call_arg_types: &[WasmType],
-        _call_args: &[ir::Value]
+        _call_args: &[ir::Value],
     ) -> WasmResult<(ir::Value, ir::Value, ir::Value)> {
         todo!()
     }
@@ -698,7 +704,12 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         todo!()
     }
 
-    fn translate_suspend(&mut self, _pos: FuncCursor, _state: &FuncTranslationState, _tag_index: u32) {
+    fn translate_suspend(
+        &mut self,
+        _pos: FuncCursor,
+        _state: &FuncTranslationState,
+        _tag_index: u32,
+    ) {
         todo!()
     }
 
@@ -718,15 +729,30 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         todo!()
     }
 
-    fn typed_continuations_load_payloads(&self, _builder: &mut FunctionBuilder, _valtypes: &[WasmType], _base_addr: ir::Value) -> Vec<ir::Value> {
+    fn typed_continuations_load_payloads(
+        &self,
+        _builder: &mut FunctionBuilder,
+        _valtypes: &[WasmType],
+        _base_addr: ir::Value,
+    ) -> Vec<ir::Value> {
         todo!()
     }
 
-    fn typed_continuations_store_payloads(&self, _builder: &mut FunctionBuilder, _valtypes: &[WasmType], _values : &[ir::Value], _base_addr: ir::Value) {
+    fn typed_continuations_store_payloads(
+        &self,
+        _builder: &mut FunctionBuilder,
+        _valtypes: &[WasmType],
+        _values: &[ir::Value],
+        _base_addr: ir::Value,
+    ) {
         todo!()
     }
 
-    fn typed_continuations_load_continuation_object(&self, _builder: &mut FunctionBuilder, _base_addr: ir::Value) -> ir::Value {
+    fn typed_continuations_load_continuation_object(
+        &self,
+        _builder: &mut FunctionBuilder,
+        _base_addr: ir::Value,
+    ) -> ir::Value {
         todo!()
     }
 }

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -564,7 +564,13 @@ pub trait FuncEnvironment: TargetEnvironment {
     }
 
     /// TODO(dhil): write documentation.
-    fn translate_cont_new(&mut self, pos: FuncCursor, state: &FuncTranslationState, func: ir::Value, arg_types : &[wasmtime_types::WasmType]) -> WasmResult<ir::Value>;
+    fn translate_cont_new(
+        &mut self,
+        pos: FuncCursor,
+        state: &FuncTranslationState,
+        func: ir::Value,
+        arg_types: &[wasmtime_types::WasmType],
+    ) -> WasmResult<ir::Value>;
 
     /// Translates a resume instruction and returns a triple (vmctx,
     /// signal, tag), where vmctx is the base address of the VM
@@ -575,9 +581,9 @@ pub trait FuncEnvironment: TargetEnvironment {
         &mut self,
         builder: &mut FunctionBuilder,
         state: &FuncTranslationState,
-        cont : ir::Value,
+        cont: ir::Value,
         call_arg_types: &[wasmtime_types::WasmType],
-        call_args: &[ir::Value]
+        call_args: &[ir::Value],
     ) -> WasmResult<(ir::Value, ir::Value, ir::Value)>;
 
     /// TODO(dhil): write documentation.
@@ -599,10 +605,21 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn continuation_returns(&self, type_index: u32) -> &[wasmtime_types::WasmType];
 
     /// TODO
-    fn typed_continuations_load_payloads(&self, builder: &mut FunctionBuilder, valtypes: &[wasmtime_types::WasmType], base_addr: ir::Value) -> std::vec::Vec<ir::Value>;
+    fn typed_continuations_load_payloads(
+        &self,
+        builder: &mut FunctionBuilder,
+        valtypes: &[wasmtime_types::WasmType],
+        base_addr: ir::Value,
+    ) -> std::vec::Vec<ir::Value>;
 
     /// TODO
-    fn typed_continuations_store_payloads(&self, builder: &mut FunctionBuilder, valtypes: &[wasmtime_types::WasmType], values : &[ir::Value], base_addr: ir::Value);
+    fn typed_continuations_store_payloads(
+        &self,
+        builder: &mut FunctionBuilder,
+        valtypes: &[wasmtime_types::WasmType],
+        values: &[ir::Value],
+        base_addr: ir::Value,
+    );
 
     /// TODO
     fn tag_params(&self, tag_index: u32) -> &[wasmtime_types::WasmType];
@@ -611,7 +628,11 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn tag_returns(&self, tag_index: u32) -> &[wasmtime_types::WasmType];
 
     /// TODO
-    fn typed_continuations_load_continuation_object(&self, builder: &mut FunctionBuilder, base_addr: ir::Value) -> ir::Value;
+    fn typed_continuations_load_continuation_object(
+        &self,
+        builder: &mut FunctionBuilder,
+        base_addr: ir::Value,
+    ) -> ir::Value;
 
     /// Returns whether the CLIF `x86_blendv` instruction should be used for the
     /// relaxed simd `*.relaxed_laneselect` instruction for the specified type.

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -6,7 +6,7 @@ use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
-use wasmparser::{FuncValidator, WasmFuncType,  WasmModuleResources};
+use wasmparser::{FuncValidator, WasmFuncType, WasmModuleResources};
 use wasmtime_types::WasmType;
 
 /// Get the parameter and result types for the given Wasm blocktype.

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -10,8 +10,8 @@ use cranelift_frontend::FunctionBuilder;
 use cranelift_frontend::Variable;
 use cranelift_wasm::{
     self, FuncIndex, FuncTranslationState, GlobalIndex, GlobalVariable, Heap, HeapData, HeapStyle,
-    MemoryIndex, TableIndex, TagIndex, TargetEnvironment, TypeIndex, WasmHeapType, WasmRefType, WasmResult,
-    WasmType,
+    MemoryIndex, TableIndex, TagIndex, TargetEnvironment, TypeIndex, WasmHeapType, WasmRefType,
+    WasmResult, WasmType,
 };
 use std::convert::TryFrom;
 use std::mem;
@@ -2205,7 +2205,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         mut pos: cranelift_codegen::cursor::FuncCursor<'_>,
         _state: &FuncTranslationState,
         func: ir::Value,
-        _arg_types : &[WasmType]
+        _arg_types: &[WasmType],
     ) -> WasmResult<ir::Value> {
         let builtin_index = BuiltinFunctionIndex::cont_new();
         let builtin_sig = self.builtin_function_signatures.cont_new(&mut pos.func);
@@ -2222,9 +2222,9 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         &mut self,
         builder: &mut FunctionBuilder,
         _state: &FuncTranslationState,
-        cont : ir::Value,
+        cont: ir::Value,
         call_arg_types: &[WasmType],
-        call_args: &[ir::Value]
+        call_args: &[ir::Value],
     ) -> WasmResult<(ir::Value, ir::Value, ir::Value)> {
         // Strategy:
         //
@@ -2245,7 +2245,6 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
         let (vmctx, builtin_addr) =
             self.translate_load_builtin_function_address(&mut builder.cursor(), builtin_index);
-
 
         // Second step: store `call_args` in the typed continuations
         // store.
@@ -2325,14 +2324,21 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         self.types[idx].returns()
     }
 
-    fn typed_continuations_load_payloads(&self, builder: &mut FunctionBuilder, valtypes: &[WasmType], base_addr: ir::Value) -> Vec<ir::Value> {
+    fn typed_continuations_load_payloads(
+        &self,
+        builder: &mut FunctionBuilder,
+        valtypes: &[WasmType],
+        base_addr: ir::Value,
+    ) -> Vec<ir::Value> {
         let memflags = ir::MemFlags::trusted().with_readonly();
         let mut values = vec![];
         if valtypes.len() == 0 {
             // OK
         } else if valtypes.len() == 1 {
             let offset = i32::try_from(self.offsets.vmctx_typed_continuations_payloads()).unwrap();
-            let val = builder.ins().load(convert_type(valtypes[0]), memflags, base_addr, offset);
+            let val = builder
+                .ins()
+                .load(convert_type(valtypes[0]), memflags, base_addr, offset);
             values.push(val)
         } else {
             panic!("Unsupported continuation arity!");
@@ -2340,7 +2346,13 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         values
     }
 
-    fn typed_continuations_store_payloads(&self, builder: &mut FunctionBuilder, valtypes: &[WasmType], values : &[ir::Value], base_addr: ir::Value) {
+    fn typed_continuations_store_payloads(
+        &self,
+        builder: &mut FunctionBuilder,
+        valtypes: &[WasmType],
+        values: &[ir::Value],
+        base_addr: ir::Value,
+    ) {
         //TODO(frank-emrich) what flags exactly do we need here?
         let memflags = ir::MemFlags::trusted();
 
@@ -2348,17 +2360,22 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             // OK
         } else if valtypes.len() == 1 {
             let offset = i32::try_from(self.offsets.vmctx_typed_continuations_payloads()).unwrap();
-             builder.ins().store(memflags,values[0],base_addr, offset);
+            builder.ins().store(memflags, values[0], base_addr, offset);
         } else {
             panic!("Unsupported continuation arity!");
         }
-
     }
 
-    fn typed_continuations_load_continuation_object(&self, builder: &mut FunctionBuilder, base_addr: ir::Value) -> ir::Value {
+    fn typed_continuations_load_continuation_object(
+        &self,
+        builder: &mut FunctionBuilder,
+        base_addr: ir::Value,
+    ) -> ir::Value {
         let memflags = ir::MemFlags::trusted().with_readonly();
         let offset = i32::try_from(self.offsets.vmctx_typed_continuations_store()).unwrap();
-        builder.ins().load(self.pointer_type(), memflags, base_addr, offset)
+        builder
+            .ins()
+            .load(self.pointer_type(), memflags, base_addr, offset)
     }
 
     fn use_x86_blendv_for_relaxed_laneselect(&self, ty: Type) -> bool {


### PR DESCRIPTION
We've neglected running `cargo fmt` on some previous PRs. Checking that code is auto-formatted is now part of the CI, but we need to bring the existing code into shape once, which this PR does.