### PR TITLE
Load payloads without readonly flag

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2330,7 +2330,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         valtypes: &[WasmType],
         base_addr: ir::Value,
     ) -> Vec<ir::Value> {
-        let memflags = ir::MemFlags::trusted().with_readonly();
+        let memflags = ir::MemFlags::trusted();
         let mut values = vec![];
         if valtypes.len() == 0 {
             // OK

--- a/tests/misc_testsuite/typed-continuations/cont_resume2.wast
+++ b/tests/misc_testsuite/typed-continuations/cont_resume2.wast
@@ -60,5 +60,5 @@
     (resume $cont_int_to_int)
     ))
 
-;; TODO(frank-emrich) This is test is currently broken
-;; (assert_return (invoke "f") (i32.const 100))
+
+(assert_return (invoke "f") (i32.const 100))


### PR DESCRIPTION
When loading payloads, we must not set the `readonly` flag. Enabling this flag allows the compiler that the load has no dependencies.
As a result, the following pattern

```
store value v1 to payload slot 1
call suspend
load payload slot 1 into v2
```

was optimised to
```
store value v1 to payload slot 1
call suspend
v2 := v1
```

Fixing this allows us to re-enable the test `const_resume2`, which exhibited this problem.