### PR TITLE
Support n-ary payloads

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2339,9 +2339,12 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             let mut offset =
                 i32::try_from(self.offsets.vmctx_typed_continuations_payloads()).unwrap();
             for valtype in valtypes {
-                let val = builder
-                    .ins()
-                    .load(convert_type(*valtype), memflags, base_addr, offset);
+                let val = builder.ins().load(
+                    super::value_type(self.isa, *valtype),
+                    memflags,
+                    base_addr,
+                    offset,
+                );
                 values.push(val);
                 offset += self.offsets.ptr.size_of_vmglobal_definition() as i32;
             }
@@ -2390,13 +2393,5 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
     fn use_x86_blendv_for_relaxed_laneselect(&self, ty: Type) -> bool {
         self.isa.has_x86_blendv_lowering(ty)
-    }
-}
-
-fn convert_type(ty: WasmType) -> ir::Type {
-    match ty {
-        WasmType::I32 => ir::types::I32,
-        WasmType::I64 => ir::types::I64,
-        _ => todo!(),
     }
 }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2346,7 +2346,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                     offset,
                 );
                 values.push(val);
-                offset += self.offsets.ptr.size_of_vmglobal_definition() as i32;
+                offset += self.offsets.ptr.maximum_value_size() as i32;
             }
         } else {
             panic!("Unsupported continuation arity!");
@@ -2372,7 +2372,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 i32::try_from(self.offsets.vmctx_typed_continuations_payloads()).unwrap();
             for value in values {
                 builder.ins().store(memflags, *value, base_addr, offset);
-                offset += self.offsets.ptr.size_of_vmglobal_definition() as i32;
+                offset += self.offsets.ptr.maximum_value_size() as i32;
             }
         } else {
             panic!("Unsupported continuation arity!");

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -16,6 +16,7 @@ use cranelift_wasm::{
 use std::convert::TryFrom;
 use std::mem;
 use wasmparser::Operator;
+use wasmtime_environ::MAXIMUM_CONTINUATION_PAYLOAD_COUNT;
 use wasmtime_environ::{
     BuiltinFunctionIndex, MemoryPlan, MemoryStyle, Module, ModuleTranslation, ModuleTypes, PtrSize,
     TableStyle, Tunables, TypeConvert, VMOffsets, WASM_PAGE_SIZE,
@@ -2334,18 +2335,23 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         let mut values = vec![];
         if valtypes.len() == 0 {
             // OK
-        } else if valtypes.len() == 1 {
-            let offset = i32::try_from(self.offsets.vmctx_typed_continuations_payloads()).unwrap();
-            let val = builder
-                .ins()
-                .load(convert_type(valtypes[0]), memflags, base_addr, offset);
-            values.push(val)
+        } else if valtypes.len() <= MAXIMUM_CONTINUATION_PAYLOAD_COUNT as usize {
+            let mut offset =
+                i32::try_from(self.offsets.vmctx_typed_continuations_payloads()).unwrap();
+            for valtype in valtypes {
+                let val = builder
+                    .ins()
+                    .load(convert_type(*valtype), memflags, base_addr, offset);
+                values.push(val);
+                offset += self.offsets.ptr.size_of_vmglobal_definition() as i32;
+            }
         } else {
             panic!("Unsupported continuation arity!");
         }
         values
     }
 
+    //TODO(frank-emrich) Consider removing `valtypes` argument, as values are inherently typed
     fn typed_continuations_store_payloads(
         &self,
         builder: &mut FunctionBuilder,
@@ -2358,9 +2364,13 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
         if valtypes.len() == 0 {
             // OK
-        } else if valtypes.len() == 1 {
-            let offset = i32::try_from(self.offsets.vmctx_typed_continuations_payloads()).unwrap();
-            builder.ins().store(memflags, values[0], base_addr, offset);
+        } else if valtypes.len() <= MAXIMUM_CONTINUATION_PAYLOAD_COUNT as usize {
+            let mut offset =
+                i32::try_from(self.offsets.vmctx_typed_continuations_payloads()).unwrap();
+            for value in values {
+                builder.ins().store(memflags, *value, base_addr, offset);
+                offset += self.offsets.ptr.size_of_vmglobal_definition() as i32;
+            }
         } else {
             panic!("Unsupported continuation arity!");
         }

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -163,6 +163,12 @@ pub trait PtrSize {
         16
     }
 
+    /// This is the size of the largest value type (i.e. a V128).
+    #[inline]
+    fn maximum_value_size(&self) -> u8 {
+        self.size_of_vmglobal_definition()
+    }
+
     // Offsets within `VMRuntimeLimits`
 
     /// Return the offset of the `stack_limit` field of `VMRuntimeLimits`
@@ -482,9 +488,8 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             size(typed_continuations_store)
                 = ret.ptr.size(),
             align(16),
-            // `size_of_vmglobal_definition` corresponds to maximum size of a value
             size(typed_continuations_payloads)
-                = cmul(MAXIMUM_CONTINUATION_PAYLOAD_COUNT, ret.ptr.size_of_vmglobal_definition()),
+                = cmul(MAXIMUM_CONTINUATION_PAYLOAD_COUNT, ret.ptr.maximum_value_size()),
             align(16), // TODO(dhil): This could probably be done more
                        // efficiently by packing the pointer into the above 16 byte
                        // alignment

--- a/tests/misc_testsuite/typed-continuations/cont_nary.wast
+++ b/tests/misc_testsuite/typed-continuations/cont_nary.wast
@@ -84,9 +84,6 @@
     (local.get $i32_acc)
     (local.get $i64_acc))
 
-
-
-
 )
 
 (assert_return (invoke "test") (i32.const 1111) (i64.const 110_000_000_000))

--- a/tests/misc_testsuite/typed-continuations/cont_nary.wast
+++ b/tests/misc_testsuite/typed-continuations/cont_nary.wast
@@ -1,0 +1,92 @@
+;; Tests using support for n-ary continuations
+;; Uses a function as continuation that has 3 param and 5 return values
+;; Uses tag that has 4 elements of payloads
+;; All of these mix i32 and i64 values
+
+
+(module
+  (type $unit_to_unit (func))
+  (type $unit_to_int (func (result i32)))
+  (type $int_to_unit (func (param i32)))
+  (type $int_to_int (func (param i32) (result i32)))
+
+
+  ;; type of function f
+  (type $f_t
+        (func
+         (param i64 i32 i64)
+         (result i32 i64 i32 i64 i32)))
+  (type $f_ct (cont $f_t))
+
+
+  ;; type of the resumption we expect to see in our handler for $e
+  (type $res_ft
+        (func
+         (param i64 i32 i64 i32)
+         (result i32 i64 i32 i64 i32)))
+  (type $res (cont $res_ft))
+
+  ;; This is 10^10, which exceeds what can be stored in any 32 bit type
+  (global $big i64 (i64.const 10_000_000_000))
+
+  (tag $e
+       (param i32 i64 i32 i64)
+       (result i64 i32 i64 i32))
+
+
+
+  (func $f (export "f")
+        (param $x i64) (param $y i32) (param $z i64)
+        (result i32 i64 i32 i64 i32)
+
+    ;; value to stay on the stack as part of return values
+    (i32.const 1)
+
+    ;; values to be passed to $e
+    (i32.const 10)
+    (local.get $z)
+    (local.get $y)
+    (local.get $x)
+    (suspend $e)
+  )
+
+  (func $test (export "test") (result i32 i64)
+    (local $i64_acc i64)
+    (local $i32_acc i32)
+    (local $k (ref $res))
+    (local.set $i64_acc (i64.const 0))
+    (local.set $i32_acc (i32.const 0))
+
+
+    (block $on_e (result i32 i64 i32 i64 (ref $res)) ;; lets call these values v1 v2 v3 v4 k
+      (global.get $big)
+      (i32.const 100)
+      (i64.mul (global.get $big) (i64.const 10))
+      (resume $f_ct (tag $e $on_e) (cont.new $f_ct (ref.func $f)))
+      (unreachable))
+    ;; after on_e
+    (local.set $k)
+    (i32.const 1000)
+    ;; We pass v2 v3 v4 123 as arguments to the continuation, leaving v1 on the stack
+    (resume $res (local.get $k))
+    ;; We now have v1 and the five return values of $f on the stack, i.e. [i32 i32 i64 i32 i64 i32]
+    ;; Lets accumulate them
+    ;;
+
+    (local.set $i32_acc (i32.add (local.get $i32_acc)))
+    (local.set $i64_acc (i64.add (local.get $i64_acc)))
+    (local.set $i32_acc (i32.add (local.get $i32_acc)))
+    (local.set $i64_acc (i64.add (local.get $i64_acc)))
+    (local.set $i32_acc (i32.add (local.get $i32_acc)))
+    (local.set $i32_acc (i32.add (local.get $i32_acc)))
+
+    ;; ;; Set up return values
+    (local.get $i32_acc)
+    (local.get $i64_acc))
+
+
+
+
+)
+
+(assert_return (invoke "test") (i32.const 1111) (i64.const 110_000_000_000))


### PR DESCRIPTION
This updates `typed_continuations_store_payloads` and `typed_continuations_load_payloads` to support arbitrary numbers of values, as long as their number is <= MAXIMUM_CONTINUATION_PAYLOAD_COUNT.

This affects payloads for all of the following:
- passing arguments to a function used as continuation
- passing arguments to tags (i.e., handlers)
- receiving data in a handler
- returning data from a function executed as a continuation (i.e., via `resume`)