### PR TITLE
Provide malloc'd fiberstacks

### DIFF
--- a/crates/fibre/src/lib.rs
+++ b/crates/fibre/src/lib.rs
@@ -29,7 +29,7 @@ impl FiberStack {
 
     /// Creates a new fiber stack of the given size (using malloc).
     pub fn malloc(size: usize) -> io::Result<Self> {
-        Ok(Self(imp::FiberStack::new(size)?))
+        Ok(Self(imp::FiberStack::malloc(size)?))
     }
 
     /// Creates a new fiber stack with the given pointer to the bottom of the

--- a/crates/fibre/src/lib.rs
+++ b/crates/fibre/src/lib.rs
@@ -27,6 +27,11 @@ impl FiberStack {
         Ok(Self(imp::FiberStack::new(size)?))
     }
 
+    /// Creates a new fiber stack of the given size (using malloc).
+    pub fn malloc(size: usize) -> io::Result<Self> {
+        Ok(Self(imp::FiberStack::new(size)?))
+    }
+
     /// Creates a new fiber stack with the given pointer to the bottom of the
     /// stack plus the byte length of the stack.
     ///

--- a/crates/fibre/src/unix.rs
+++ b/crates/fibre/src/unix.rs
@@ -36,6 +36,7 @@ use std::cell::Cell;
 use std::io;
 use std::ops::Range;
 use std::ptr;
+use std::alloc::{alloc, dealloc, Layout};
 
 #[derive(Debug)]
 pub struct FiberStack {
@@ -83,6 +84,14 @@ impl FiberStack {
         }
     }
 
+    pub fn malloc(size: usize) -> io::Result<Self> {
+        unsafe {
+            let layout = Layout::array::<u8>(size).unwrap();
+            let top = alloc(layout);
+            FiberStack::from_raw_parts(top, size)
+        }
+    }
+
     pub unsafe fn from_raw_parts(base: *mut u8, len: usize) -> io::Result<Self> {
         Ok(Self {
             top: base.add(len),
@@ -115,6 +124,9 @@ impl Drop for FiberStack {
             if self.mmap {
                 let ret = rustix::mm::munmap(self.top.sub(self.len) as _, self.len);
                 debug_assert!(ret.is_ok());
+            } else {
+                let layout = Layout::array::<u8>(self.len).unwrap();
+                dealloc(self.top.sub(self.len), layout);
             }
         }
     }

--- a/crates/fibre/src/unix.rs
+++ b/crates/fibre/src/unix.rs
@@ -32,11 +32,11 @@
 #![allow(unused_macros)]
 
 use crate::RunResult;
+use std::alloc::{alloc, dealloc, Layout};
 use std::cell::Cell;
 use std::io;
 use std::ops::Range;
 use std::ptr;
-use std::alloc::{alloc, dealloc, Layout};
 
 #[derive(Debug)]
 pub struct FiberStack {

--- a/crates/fibre/src/unix.rs
+++ b/crates/fibre/src/unix.rs
@@ -87,8 +87,8 @@ impl FiberStack {
     pub fn malloc(size: usize) -> io::Result<Self> {
         unsafe {
             let layout = Layout::array::<u8>(size).unwrap();
-            let top = alloc(layout);
-            FiberStack::from_raw_parts(top, size)
+            let base = alloc(layout);
+            FiberStack::from_raw_parts(base, size)
         }
     }
 

--- a/crates/fibre/src/windows.rs
+++ b/crates/fibre/src/windows.rs
@@ -15,6 +15,10 @@ impl FiberStack {
         Ok(Self(size))
     }
 
+    pub fn malloc(_size: usize) -> io::Result<Self> {
+        unimplemented!()
+    }
+
     pub unsafe fn from_raw_parts(_base: *mut u8, _len: usize) -> io::Result<Self> {
         Err(io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32))
     }

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -284,7 +284,7 @@ pub fn cont_new(
     let args_ptr = payload.data;
     let fiber = Box::new(
         Fiber::new(
-            FiberStack::new(4096).unwrap(),
+            FiberStack::malloc(4096).unwrap(),
             move |_first_val: (), _suspend: &Yield| unsafe {
                 f(callee_ctx, caller_ctx, args_ptr as *mut ValRaw, capacity)
             },


### PR DESCRIPTION
This patch extends the `Fibre::FiberStack` interface with a method for allocating the stack using malloc.