### PR TITLE
Improve compile option for disabling the continuation linearity check.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,10 @@ winch = ["wasmtime/winch"]
 # may otherwise run out of memory.
 # Note that enabling this is highly unsafe, as it makes it impossible to detect
 # at runtime when an already taken continuation is used again.
-use_contobj_as_contref = []
+unsafe_disable_continuation_linearity_check = [
+  "wasmtime-cranelift/unsafe_disable_continuation_linearity_check",
+  "wasmtime-runtime/unsafe_disable_continuation_linearity_check"
+]
 
 [[test]]
 name = "host_segfault"

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -31,3 +31,4 @@ thiserror = { workspace = true }
 all-arch = ["cranelift-codegen/all-arch"]
 component-model = ["wasmtime-environ/component-model"]
 incremental-cache = ["cranelift-codegen/incremental-cache"]
+unsafe_disable_continuation_linearity_check = []

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2434,7 +2434,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         builder: &mut FunctionBuilder,
         contref: ir::Value,
     ) -> ir::Value {
-        if cfg!(feature = "use_contobj_as_contref") {
+        if cfg!(feature = "unsafe_disable_continuation_linearity_check") {
             // The "contref" is a contobj already
             return contref;
         } else {
@@ -2550,7 +2550,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         builder: &mut FunctionBuilder,
         contobj_addr: ir::Value,
     ) -> ir::Value {
-        if cfg!(feature = "use_contobj_as_contref") {
+        if cfg!(feature = "unsafe_disable_continuation_linearity_check") {
             return contobj_addr;
         } else {
             let (_vmctx, contref) =

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -67,3 +67,5 @@ component-model = [
   "wasmtime-environ/component-model",
   "dep:encoding_rs",
 ]
+
+unsafe_disable_continuation_linearity_check = []

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -94,7 +94,9 @@ pub fn cont_ref_get_cont_obj(
     //FIXME rename to indicate that this invalidates the cont ref
 
     // If this is enabled, we should never call this function.
-    assert!(!cfg!(feature = "unsafe_disable_continuation_linearity_check"));
+    assert!(!cfg!(
+        feature = "unsafe_disable_continuation_linearity_check"
+    ));
 
     let contopt = unsafe { contref.as_mut().unwrap().0 };
     match contopt {
@@ -186,7 +188,9 @@ pub fn cont_obj_has_state_invoked(obj: *mut ContinuationObject) -> bool {
 #[inline(always)]
 pub fn new_cont_ref(contobj: *mut ContinuationObject) -> *mut ContinuationReference {
     // If this is enabled, we should never call this function.
-    assert!(!cfg!(feature = "unsafe_disable_continuation_linearity_check"));
+    assert!(!cfg!(
+        feature = "unsafe_disable_continuation_linearity_check"
+    ));
 
     let contref = Box::new(ContinuationReference(Some(contobj)));
     Box::into_raw(contref)

--- a/crates/runtime/src/continuation.rs
+++ b/crates/runtime/src/continuation.rs
@@ -94,7 +94,7 @@ pub fn cont_ref_get_cont_obj(
     //FIXME rename to indicate that this invalidates the cont ref
 
     // If this is enabled, we should never call this function.
-    assert!(!cfg!(feature = "use_contobj_as_contref"));
+    assert!(!cfg!(feature = "unsafe_disable_continuation_linearity_check"));
 
     let contopt = unsafe { contref.as_mut().unwrap().0 };
     match contopt {
@@ -186,7 +186,7 @@ pub fn cont_obj_has_state_invoked(obj: *mut ContinuationObject) -> bool {
 #[inline(always)]
 pub fn new_cont_ref(contobj: *mut ContinuationObject) -> *mut ContinuationReference {
     // If this is enabled, we should never call this function.
-    assert!(!cfg!(feature = "use_contobj_as_contref"));
+    assert!(!cfg!(feature = "unsafe_disable_continuation_linearity_check"));
 
     let contref = Box::new(ContinuationReference(Some(contobj)));
     Box::into_raw(contref)


### PR DESCRIPTION
This patch improves upon #42. In addition it renames the flag, so to build a compiler & runtime without linearity checking one has to supply the following:

```shell
$ cargo build --features=default,unsafe_disable_continuation_linearity_check
```